### PR TITLE
Avoid possible `println!` errors when piped

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,6 @@ mod renderer;
 
 use config::Config;
 
-// re: panic when piping to e.g. head
-//https://github.com/rust-lang/rust/issues/24821#issuecomment-96276655
-
 fn main() -> Result<(), Box<Error>> {
   let config = Arc::new(Config::from_args());
 

--- a/src/renderer/plain.rs
+++ b/src/renderer/plain.rs
@@ -1,6 +1,7 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP
 
 use std::cmp::max;
+use std::io::{self, Write};
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 use std::thread::{self, JoinHandle};
@@ -94,7 +95,11 @@ pub fn plain_renderer(_: Arc<Config>, rx: Receiver<LogEntry>) -> JoinHandle<()> 
 
       if let Some(message) = entry.message {
         for line in plain_render(&message) {
-          println!("{}", line);
+          // println! may fail when piped to e.g. head
+          // see also: https://github.com/rust-lang/rust/issues/24821
+          if writeln!(io::stdout(), "{}", line).is_err() {
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
rust's `println!()` macro panics if the output stream is closed,
which may happen when the output is piped to tools that only read a
portion of the output like e.g. `head` or ironically, `woodchipper`
itself.

Instead, use `write!()` and silently quit if the output stream goes
away.