### PR TITLE
Add a warning if no input is detected

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,9 +4,10 @@ pub mod types;
 pub mod stdin;
 pub mod stdin_hack;
 pub mod kubernetes;
+pub mod null;
 
 pub use types::Reader;
 pub use stdin::read_stdin;
 pub use stdin_hack::read_stdin_hack;
 pub use kubernetes::read_kubernetes_selector;
-
+pub use null::read_null;

--- a/src/reader/null.rs
+++ b/src/reader/null.rs
@@ -1,0 +1,33 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread::{self, JoinHandle};
+
+use simple_error::SimpleResult;
+
+use crate::config::Config;
+use crate::renderer::LogEntry;
+
+/// A simple reader to display an error if autodetection fails
+pub fn read_null(
+  _config: Arc<Config>,
+  tx: Sender<LogEntry>,
+  _exit_req_rx: Receiver<()>,
+  _exit_resp_tx: Sender<()>
+) -> JoinHandle<SimpleResult<()>> {
+  thread::Builder::new().name("read_null".to_string()).spawn(move || {
+    tx.send(LogEntry::internal(
+      "error: no reader was detected automatically, either select a reader \
+      (e.g. -r kubernetes) or pipe in some input"
+    )).ok();
+
+    tx.send(LogEntry::internal(
+      "error: see woodchipper --help for details"
+    )).ok();
+
+    tx.send(LogEntry::eof()).ok();
+
+    Ok(())
+  }).unwrap()
+}


### PR DESCRIPTION
Use atty to check if stdin is a tty and, if no other readers are
available (e.g. kubernetes), return the null_reader.

The null reader simply prints an error message and quits. `main.rs`
will preemptively check the reader implementation and show a more
sensible error/usage message without starting the renderer.