### PR TITLE
Add klog parser

### DIFF
--- a/src/classifier/context.rs
+++ b/src/classifier/context.rs
@@ -45,4 +45,3 @@ pub fn classify_context(
 
   ret
 }
-

--- a/src/parser/klog.rs
+++ b/src/parser/klog.rs
@@ -1,0 +1,85 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+use std::collections::HashMap;
+use std::error::Error;
+
+use chrono::prelude::*;
+use regex::Regex;
+use serde_json::Value;
+
+use super::types::{LogLevel, Message, MessageKind, ReaderMetadata};
+
+fn map_klog_level(level: &str) -> Option<LogLevel> {
+  match level {
+    "D" => Some(LogLevel::Debug), // not technically supported by klog
+    "I" => Some(LogLevel::Info),
+    "W" => Some(LogLevel::Warning),
+    "E" => Some(LogLevel::Error),
+    "F" => Some(LogLevel::Fatal),
+    _ => None
+  }
+}
+
+// parses klog-style messages
+//
+// based on the format description at:
+// https://github.com/kubernetes/klog/blob/master/klog.go#L592-L602
+pub fn parse_klog(
+  line: &str, meta: Option<ReaderMetadata>
+) -> Result<Option<Message>, Box<Error>> {
+  lazy_static! {
+    static ref RE: Regex = Regex::new(
+      r"^([A-Z])(\d{4} \d{2}:\d{2}:[\d\.]+)\s+(\d+) ([\S.]+:\d+)] (.+)$"
+    ).unwrap();
+  }
+
+  if let Some(caps) = RE.captures(line) {
+    // naughty unwrapping, but we have a constant number of groups
+    let level = map_klog_level(caps.get(1).unwrap().as_str());
+
+    let timestamp_str = caps.get(2).unwrap().as_str();
+    
+    // ex: 0607 19:28:33.579841
+    let reader_timestamp = if let Some(meta) = &meta {
+      if let Some(timestamp) = &meta.timestamp {
+        Some(*timestamp)
+      } else {
+        None
+      }
+    } else { None };
+
+    let timestamp = Utc.datetime_from_str(
+      timestamp_str,
+      "%m%d %H:%M:%S:%.f"
+    ).ok().or(reader_timestamp);
+    let text = caps.get(5).unwrap().as_str();
+
+    let mut metadata = HashMap::new();
+
+    let maybe_thread_id = caps.get(3)
+      .map(|c| c.as_str())
+      .and_then(|s| s.parse::<isize>().ok());
+    if let Some(thread_id) = maybe_thread_id {
+      metadata.insert("threadId".to_string(), Value::Number(thread_id.into()));
+    }
+
+    if let Some(context) = caps.get(4).map(|c| c.as_str()) {
+      metadata.insert(
+        "caller".to_string(),
+        Value::String(context.to_string())
+      );
+    }
+
+    return Ok(Some(Message {
+      kind: MessageKind::Klog,
+      reader_metadata: meta,
+      text: Some(text.to_string()),
+
+      timestamp, level, metadata,
+
+      mapped_fields: hashmap!{}
+    }));
+  }
+
+  Ok(None)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,10 +1,11 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP
 
-pub mod util;
-mod types;
-mod logrus;
 mod json;
+mod klog;
+mod logrus;
 mod plain;
+mod types;
+pub mod util;
 
 use std::error::Error;
 
@@ -13,6 +14,7 @@ pub use types::{LogLevel, Message, MessageKind, ReaderMetadata, Parser};
 static PARSERS: &[Parser] = &[
   json::parse_json,
   logrus::parse_logrus,
+  klog::parse_klog,
   plain::parse_plain
 ];
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -24,6 +24,8 @@ pub type Parser = fn(
 pub enum MessageKind {
   Json,
   Plain,
+  Logrus,
+  Klog,
   Internal
 }
 


### PR DESCRIPTION
This adds a new regex-based parser for [klog], the log format used by
Kubernetes and many Kubernetes addons.

Closes #6

[klog]: https://github.com/kubernetes/klog/