### PR TITLE
Fix kelog date parsing

### DIFF
--- a/src/parser/klog.rs
+++ b/src/parser/klog.rs
@@ -37,7 +37,13 @@ pub fn parse_klog(
     // naughty unwrapping, but we have a constant number of groups
     let level = map_klog_level(caps.get(1).unwrap().as_str());
 
-    let timestamp_str = caps.get(2).unwrap().as_str();
+    // chrono needs a year but klog omits this, so fill in the current year
+    let current_year = Utc::now().year();
+    let timestamp_str = format!(
+      "{} {}",
+      current_year,
+      caps.get(2).unwrap().as_str()
+    );
     
     // ex: 0607 19:28:33.579841
     let reader_timestamp = if let Some(meta) = &meta {
@@ -49,9 +55,10 @@ pub fn parse_klog(
     } else { None };
 
     let timestamp = Utc.datetime_from_str(
-      timestamp_str,
-      "%m%d %H:%M:%S:%.f"
+      &timestamp_str,
+      "%Y %m%d %H:%M:%S%.f"
     ).ok().or(reader_timestamp);
+
     let text = caps.get(5).unwrap().as_str();
 
     let mut metadata = HashMap::new();


### PR DESCRIPTION
klog's date parser had multiple issues that were masked by missing
dates getting filled in by the reader metadata:

  - the strftime format was incorrect, specifically with fractional
    seconds
  - klog does not have a year field and chrono requires one; the year
    is now filled in using the local UTC year

Signed-off-by: Tim Buckley <timothyb89@gmail.com>