### PR TITLE
Add a generic regex parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
               cargo update -p woodchipper
             fi
       - run:
+          name: Run unit tests on linux x86_64
+          command: cargo test
+      - run:
           name: Build static linux x86_64
           command: cargo build --release --locked
       - save_cache:
@@ -62,6 +65,8 @@ jobs:
 
               cargo update -p woodchipper
             fi
+      # running unit tests on cross-compiled windows binaries doesn't seem
+      # especially productive
       - run:
           name: Build windows x86_64
           command: |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ terminal.
    reflow, and clipboard support
  * Built-in Kubernetes support follows multiple pods and containers at
    once
+ * User-customizable output styles and custom log formats (see [customization])
 
 ## Quick Start
 
@@ -121,6 +122,7 @@ potentially mixed together:
  * [logrus]-style key/value pair logs, e.g. `time="..." msg="hello world"`
  * [klog] logs for Kubernetes components
  * Plaintext logs with inferred timestamps and log levels
+ * User-specified custom formats with the [regex parser][regex]
 
 ## Similar Projects
 
@@ -150,9 +152,11 @@ end of your commit message.
 Additionally, the [design documentation][design] may be a helpful resource for
 understanding how woodchipper works.
 
+[customization]: ./doc/customization.md
 [plugin]: ./misc/kubectl-woodchipper
 [releases]: https://github.com/HewlettPackard/woodchipper/releases/latest
 [klog]: https://github.com/kubernetes/klog
+[regex]: ./doc/customization.md#log-formats
 [stern]: https://github.com/wercker/stern
 [logrus]: https://github.com/sirupsen/logrus
 [slog]: https://github.com/slog-rs/slog

--- a/doc/customization.md
+++ b/doc/customization.md
@@ -1,0 +1,147 @@
+# Customization
+
+woodchipper can be customized using command-line flags and environment
+variables.
+
+A few of the more complex options are discussed here, but for a full list of
+options, refer to `woodchipper --help`.
+
+## Color Schemes
+
+woodchipper can use any [base16 color scheme][base16]. To use:
+
+ * Save a scheme's `.yaml` configuration somewhere local, e.g.
+   [`classic-dark.yaml`][classic-dark]
+ * Run woodchipper with `--style=base16:path/to/classic-dark.yaml`
+ * Once satisfied with results, set:
+
+   ```
+   export WD_STYLE=base16:path/to/classic-dark.yaml
+   ```
+
+   ...in your environment.
+
+[base16]: https://github.com/chriskempson/base16#scheme-repositories
+[classic-dark]: https://github.com/detly/base16-classic-scheme/blob/master/classic-dark.yaml
+
+## Log Formats
+
+In addition to the built-in formats, woodchipper supports custom regex-based
+parsers. These can be used to support many application-specific log formats that
+don't require a more advanced parser.
+
+To add a custom log format, create a `.yaml` file containing a list of regexes:
+
+```yaml
+- pattern: ...
+  datetime: ...
+
+- pattern: ...
+  datetime: ...
+  datetime_prepend: ...
+```
+
+Each `pattern` field should contain a regex with various
+[named capture groups][groups]:
+ * `(?P<datetime>...)`
+
+   Captures the datetime string - this is further parsed later using the format
+   set in the `datetime` field.
+ * `(?P<level>...)`
+
+   Captures the log level (`I`, `INFO`, etc; case insensitive)
+ * `(?P<text>...)`
+
+   Captures the main message text.
+
+Any additional named capture groups will be added as message metadata. Certain
+classifiers may have special display-time rules for metadata fields; for
+example, the `file` or `caller` fields will be shown as right-aligned context
+if there's enough available screen width.
+
+The `datetime` field contains parsing rules for the captured `datetime` field.
+It has two built-in formats, `rfc2822` and `rfc3339`, but a free-form
+[chrono `stftime`][strftime] string can be set here as well.
+
+Note that chrono requires fully-formed datetime strings, and won't fill in
+missing fields for you. If your log format omits some fields (e.g. `klog`
+doesn't output the year), you can use `datetime_prepend` to add missing fields
+to the incoming datetime string based on the current UTC time. This field should
+contain another strftime format string with only the missing fields from the
+original input.
+
+Finally, to make use of the regex config, first test with:
+
+```
+woodchipper --regexes path/to/regexes.yaml
+```
+
+... and once satisfied with the results, add:
+
+```bash
+export WD_REGEXES=path/to/regexes.yaml
+```
+
+... to your environment.
+
+[groups]: https://docs.rs/regex/1.1.7/regex/#grouping-and-flags
+[strftime]: https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html
+
+### Example
+
+As an example, take this Python logging example, `logs.py`:
+
+```python
+import logging
+
+logging.basicConfig(
+    format='%(asctime)-15s - %(levelname)-8s - %(filename)s:%(lineno)d - %(message)s',
+    level='DEBUG'
+)
+
+logger = logging.getLogger('test')
+logger.debug('this is a debug message')
+logger.info('this is an info message')
+logger.warning('this is a warning message')
+logger.error('this is an error message')
+```
+
+It produces log messages like this:
+```
+$ python3 -u logs.py 2>&1
+2019-07-03 12:02:13,977 - DEBUG    - test.py:9 - this is a debug message
+2019-07-03 12:02:13,977 - INFO     - test.py:10 - this is an info message
+2019-07-03 12:02:13,977 - WARNING  - test.py:11 - this is a warning message
+2019-07-03 12:02:13,977 - ERROR    - test.py:12 - this is an error message
+```
+
+Create a YAML file, e.g. `~/.woodchipper-regexes.yaml` with the following
+content:
+
+```yaml
+- pattern: |-
+    ^(?P<datetime>[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})(?:,[0-9]+) - (?P<level>\w+)\s* - (?P<file>\S+)\s* -(?P<text>.+)$
+  datetime: '%Y-%m-%d %H:%M:%S'
+```
+
+Now pipe it through `woodchipper` with the `--regexes` flag set to point to your
+YAML file:
+
+```
+$ python3 -u test.py 2>&1 | woodchipper -r json --regexes ~/.woodchipper-regexes.yaml
+{"kind":"regex","timestamp":"2019-07-03T12:07:15Z","level":"debug","text":" this is a debug message","metadata":{"file":"test.py:9"}}
+{"kind":"regex","timestamp":"2019-07-03T12:07:15Z","level":"info","text":" this is an info message","metadata":{"file":"test.py:10"}}
+{"kind":"regex","timestamp":"2019-07-03T12:07:15Z","level":"warning","text":" this is a warning message","metadata":{"file":"test.py:11"}}
+{"kind":"regex","timestamp":"2019-07-03T12:07:15Z","level":"error","text":" this is an error message","metadata":{"file":"test.py:12"}}
+```
+
+The three primary fields (timestamp, level, text) were captured, along with an
+additional metadata field containing the `file`.
+
+Note that chrono's strftime doesn't seem to support custom millisecond separator
+characters if they aren't right-aligned to a particular width, and python's
+`%(asctime)` seems to like using commas. The example pattern above just excludes
+the milliseconds as they won't be displayed anyway.
+
+Finally, `WD_REGEXES` may be set in your environment to make use of this regex
+configuration without needing to manually pass in `--regexes`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,7 +202,7 @@ pub struct RegexMapping {
   pub datetime_prepend: Option<String>
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct RegexConfig {
   pub mappings: Vec<RegexMapping>
 }
@@ -216,7 +216,7 @@ impl FromStr for RegexConfig {
     let reader = BufReader::new(file);
 
     match serde_yaml::from_reader(reader) {
-      Ok(config) => Ok(config),
+      Ok(mappings) => Ok(RegexConfig { mappings }),
       Err(e) => Err(SimpleError::new(
         format!("error loading regexes {}: {:?}", path, e)
       ))
@@ -284,6 +284,8 @@ pub struct Config {
   #[structopt(long, short = "s", default_value = "default", env = "WD_STYLE")]
   pub style: StyleConfig,
 
+  /// A path to a regexes config file, which may contain custom parsing regexes
+  /// for application-specific log formats.
   #[structopt(long, env = "WD_REGEXES")]
   pub regexes: Option<RegexConfig>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use atty::{self, Stream};
 use regex::Regex;
 use serde::Deserialize;
-use serde::de::{self, Visitor, Unexpected, Deserializer};
+use serde::de::{self, Visitor, Deserializer};
 use shellexpand;
-use simple_error::{SimpleError, SimpleResult};
+use simple_error::SimpleError;
 use structopt::StructOpt;
 
 use crate::style::StyleConfig;
@@ -200,6 +200,17 @@ pub struct RegexMapping {
   /// some log formats (e.g. klog) leave certain fields out. This allows these
   /// formats to be parsed anyway.
   pub datetime_prepend: Option<String>
+}
+
+impl RegexMapping {
+  /// Manually creates a new RegexMapping; used mainly in tests
+  pub fn from_str(pattern: &str, datetime: &str) -> RegexMapping {
+    RegexMapping {
+      pattern: Regex::new(pattern).unwrap(),
+      datetime: Some(String::from(datetime)),
+      datetime_prepend: None
+    }
+  }
 }
 
 #[derive(Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,17 +202,6 @@ pub struct RegexMapping {
   pub datetime_prepend: Option<String>
 }
 
-impl RegexMapping {
-  /// Manually creates a new RegexMapping; used mainly in tests
-  pub fn from_str(pattern: &str, datetime: &str) -> RegexMapping {
-    RegexMapping {
-      pattern: Regex::new(pattern).unwrap(),
-      datetime: Some(String::from(datetime)),
-      datetime_prepend: None
-    }
-  }
-}
-
 #[derive(Debug)]
 pub struct RegexConfig {
   pub mappings: Vec<RegexMapping>

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -2,11 +2,13 @@
 
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 
 use chrono::prelude::*;
 use regex::Regex;
 use serde_json::{self, Value, Map};
 
+use crate::config::Config;
 use super::types::{
   LogLevel, MappingField, Message, MessageKind, ReaderMetadata
 };
@@ -156,7 +158,7 @@ pub fn parse_document(
 }
 
 pub fn parse_json(
-  line: &str, meta: Option<ReaderMetadata>
+  _config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
   // skip anything that doesn't at least vaguely look like json
   if !line.starts_with('{') || !line.ends_with('}') {

--- a/src/parser/klog.rs
+++ b/src/parser/klog.rs
@@ -2,11 +2,13 @@
 
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 
 use chrono::prelude::*;
 use regex::Regex;
 use serde_json::Value;
 
+use crate::config::Config;
 use super::types::{LogLevel, Message, MessageKind, ReaderMetadata};
 
 fn map_klog_level(level: &str) -> Option<LogLevel> {
@@ -25,7 +27,7 @@ fn map_klog_level(level: &str) -> Option<LogLevel> {
 // based on the format description at:
 // https://github.com/kubernetes/klog/blob/master/klog.go#L592-L602
 pub fn parse_klog(
-  line: &str, meta: Option<ReaderMetadata>
+  _config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
   lazy_static! {
     static ref RE: Regex = Regex::new(

--- a/src/parser/logrus.rs
+++ b/src/parser/logrus.rs
@@ -1,11 +1,13 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP
 
 use std::error::Error;
+use std::sync::Arc;
 
 use pest::Parser;
 use serde_json::{self, Value, Map};
 use simple_error::SimpleError;
 
+use crate::config::Config;
 use super::types::{Message, ReaderMetadata};
 use super::json::parse_document;
 
@@ -64,7 +66,7 @@ pub fn logrus_to_document(
 }
 
 pub fn parse_logrus(
-  line: &str, meta: Option<ReaderMetadata>
+  _config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
   match logrus_to_document(line) {
     Ok(doc) => parse_document(doc, meta),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,25 +4,29 @@ mod json;
 mod klog;
 mod logrus;
 mod plain;
+mod regex;
 mod types;
 pub mod util;
 
 use std::error::Error;
+use std::sync::Arc;
 
+use crate::config::Config;
 pub use types::{LogLevel, Message, MessageKind, ReaderMetadata, Parser};
 
 static PARSERS: &[Parser] = &[
   json::parse_json,
   logrus::parse_logrus,
   klog::parse_klog,
+  regex::parse_regex,
   plain::parse_plain
 ];
 
 pub fn parse(
-  line: &str, meta: Option<ReaderMetadata>
+  config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
   for parser_fn in PARSERS {
-    let result = parser_fn(line, meta.clone());
+    let result = parser_fn(Arc::clone(&config), line, meta.clone());
 
     match result {
       Ok(None) => continue,

--- a/src/parser/plain.rs
+++ b/src/parser/plain.rs
@@ -2,11 +2,13 @@
 
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 
 use chrono::prelude::*;
 use dtparse::Parser;
 use regex::RegexSet;
 
+use crate::config::Config;
 use super::types::{LogLevel, Message, MessageKind, ReaderMetadata};
 use super::util::normalize_datetime;
 
@@ -91,7 +93,7 @@ fn get_meta_timestamp(meta: &Option<ReaderMetadata>) -> Option<DateTime<Utc>> {
 }
 
 pub fn parse_plain(
-  line: &str, meta: Option<ReaderMetadata>
+  _config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
   let timestamp = if let Some(timestamp) = get_meta_timestamp(&meta) {
     Some(timestamp)

--- a/src/parser/regex.rs
+++ b/src/parser/regex.rs
@@ -1,0 +1,136 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::iter::FromIterator;
+use std::sync::Arc;
+
+use chrono::prelude::*;
+use serde_json::Value;
+
+use crate::config::{Config, RegexMapping};
+use super::types::{LogLevel, Message, MessageKind, ReaderMetadata};
+use super::util::normalize_datetime;
+
+fn parse_rfc2822(s: &str) -> Option<DateTime<Utc>> {
+  match DateTime::parse_from_rfc2822(s) {
+    Ok(d) => Some(normalize_datetime(&d.naive_local(), Some(*d.offset()))),
+    Err(_) => None
+  }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+  match DateTime::parse_from_rfc3339(s) {
+    Ok(d) => Some(normalize_datetime(&d.naive_local(), Some(*d.offset()))),
+    Err(_) => None
+  }
+}
+
+fn parse_format(
+  s: &str, fmt: &str, prepend: &Option<String>
+) -> Option<DateTime<Utc>> {
+  let datetime = if let Some(prepend) = prepend {
+    format!(
+      "{} {}",
+      Utc::now().format(prepend),
+      s
+    )
+  } else {
+    String::from(s)
+  };
+
+  Utc.datetime_from_str(&datetime, fmt).ok()
+}
+
+fn parse_datetime(
+  fmt: &str, datetime: &str, prepend: &Option<String>
+) -> Option<DateTime<Utc>> {
+  match fmt {
+    "rfc2822" => parse_rfc2822(datetime),
+    "rfc3339" => parse_rfc3339(datetime),
+    _ => parse_format(datetime, fmt, prepend)
+  }
+}
+
+fn parse_mapping(
+  line: &str, mapping: &RegexMapping, meta: &Option<ReaderMetadata>
+) -> Result<Option<Message>, Box<Error>> {
+  let caps = match mapping.pattern.captures(line) {
+    Some(caps) => caps,
+    None => return Ok(None)
+  };
+
+  let mut group_names: HashSet<String> = HashSet::from_iter(
+    mapping.pattern.capture_names().filter_map(|n| n.map(String::from))
+  );
+
+  let timestamp = if let Some(datetime) = caps.name("datetime") {
+    if let Some(format) = &mapping.datetime {
+      group_names.remove("datetime");
+
+      parse_datetime(&format, datetime.as_str(), &mapping.datetime_prepend)
+    } else {
+      None
+    }
+  } else {
+    None
+  };
+
+  let text = if let Some(text) = caps.name("text") {
+    group_names.remove("text");
+
+    Some(String::from(text.as_str()))
+  } else {
+    None
+  };
+
+  let level = if let Some(level) = caps.name("level") {
+    group_names.remove("level");
+
+    match level.as_str().parse::<LogLevel>() {
+      Ok(l) => Some(l),
+      Err(_) => None
+    }
+  } else {
+    None
+  };
+
+  // collect all other capture groups into the metadata
+  let mut metadata = HashMap::new();
+  for name in group_names {
+    if let Some(mat) = caps.name(&name) {
+      metadata.insert(
+        name,
+        Value::String(String::from(mat.as_str()))
+      );
+    }
+  }
+
+  let message = Message {
+    kind: MessageKind::Regex,
+    reader_metadata: meta.clone(),
+    timestamp, level, text, metadata,
+    mapped_fields: HashMap::new()
+  };
+
+  Ok(Some(message))
+}
+
+/// attempts to parse a line using one or more user-specified regexes with named
+/// capture groups
+pub fn parse_regex(
+  config: Arc<Config>,
+  line: &str, meta: Option<ReaderMetadata>
+) -> Result<Option<Message>, Box<Error>> {
+  if let Some(regexes) = &config.regexes {
+    for mapping in &regexes.mappings {
+      match parse_mapping(line, mapping, &meta) {
+        Ok(Some(message)) => return Ok(Some(message)),
+        Ok(None) => continue,
+        Err(e) => return Err(e)
+      };
+    }
+  }
+  
+  Ok(None)
+}

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -5,18 +5,20 @@ use std::error::Error;
 use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::offset::Utc;
 use serde::{Serialize, Deserialize};
-
 use serde_json::Value;
+
+use crate::config::Config;
 
 /// Attempts to parse a log line.
 /// Returns Ok(Some(Message)) on success, Err on error, or Ok(None) to pass the
 /// message to the next parser.
 pub type Parser = fn(
-  line: &str, meta: Option<ReaderMetadata>
+  config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
@@ -26,6 +28,7 @@ pub enum MessageKind {
   Plain,
   Logrus,
   Klog,
+  Regex,
   Internal
 }
 

--- a/src/reader/stdin.rs
+++ b/src/reader/stdin.rs
@@ -20,7 +20,7 @@ use crate::renderer::LogEntry;
 // wrong for our use case)
 
 pub fn read_stdin(
-  _config: Arc<Config>,
+  config: Arc<Config>,
   tx: Sender<LogEntry>,
   _exit_req_rx: Receiver<()>,
   _exit_resp_tx: Sender<()>
@@ -35,7 +35,7 @@ pub fn read_stdin(
       let line = line.map_err(SimpleError::from)?;
       empty = false;
 
-      match LogEntry::message(&line, None) {
+      match LogEntry::message(Arc::clone(&config), &line, None) {
         Ok(Some(entry)) => match tx.send(entry) {
           Ok(_) => (),
           // assume receiver has quit and stop

--- a/src/reader/stdin_hack.rs
+++ b/src/reader/stdin_hack.rs
@@ -18,7 +18,7 @@ use crate::renderer::LogEntry;
 /// note that this _probably_ only works on linux, other OSes may need to run
 /// their application via a subprocess or just fall back to the styled renderer
 pub fn read_stdin_hack(
-  _config: Arc<Config>,
+  config: Arc<Config>,
   tx: Sender<LogEntry>,
   _exit_req_rx: Receiver<()>,
   _exit_resp_tx: Sender<()>
@@ -31,7 +31,7 @@ pub fn read_stdin_hack(
       let line = line.map_err(SimpleError::from)?;
       empty = false;
 
-      match LogEntry::message(&line, None) {
+      match LogEntry::message(Arc::clone(&config), &line, None) {
         Ok(Some(entry)) => match tx.send(entry) {
           Ok(_) => (),
           Err(_) => break

--- a/src/renderer/common.rs
+++ b/src/renderer/common.rs
@@ -685,8 +685,8 @@ mod tests {
     assert_that!(&merge_chunks(&spacers(1), &normal).width).is_equal_to(10);
 
     let merged = merge_chunks(&spacers(3), &normal);
-    assert_that!(merged.width).is_equal_to(30);
-    assert_that!(merged.content.chars().count()).is_equal_to(30);
+    assert_that!(merged.width).is_equal_to(32);
+    assert_that!(merged.content.chars().count()).is_equal_to(32);
   }
 
   #[test]
@@ -715,8 +715,8 @@ mod tests {
   fn test_merge_chunks_unpadded() {
     let merged = merge_chunks_unpadded(&spacers(3));
     assert_that!(merged.width).is_equal_to(30);
-    assert_that!(merged.pad_left).is_equal_to(false);
-    assert_that!(merged.pad_right).is_equal_to(false);
+    assert_that!(merged.pad_left).is_equal_to(true);
+    assert_that!(merged.pad_right).is_equal_to(true);
 
     let merged = merge_chunks_unpadded(&get_simple_padded());
     assert_that!(merged.content).is_equal_to("foobarbaz".to_string());
@@ -769,7 +769,7 @@ mod tests {
   #[test]
   fn test_measure_chunks() {
     assert_that!(measure_chunks(&spacers(1))).is_equal_to(10);
-    assert_that!(measure_chunks(&spacers(3))).is_equal_to(30);
+    assert_that!(measure_chunks(&spacers(3))).is_equal_to(32);
     assert_that!(measure_chunks(&get_simple_padded())).is_equal_to(11);
     assert_that!(measure_chunks(&get_simple_unpadded())).is_equal_to(9);
 

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -69,9 +69,9 @@ impl LogEntry {
   }
 
   pub fn message(
-    line: &str, meta: Option<ReaderMetadata>
+    config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
   ) -> Result<Option<LogEntry>, Box<Error>> {
-    let message = match parse(&line, meta)? {
+    let message = match parse(config, &line, meta)? {
       Some(message) => message,
       None => return Ok(None)
     };


### PR DESCRIPTION
This adds a new parser that allows users to configure any number of
regexes to parse custom formats. These are stored in a `.yaml` file
which can be configured using `--regexes path/to/file.yaml` or by
setting `$WD_REGEXES`.

Fields are extracted using named capture groups, and aside from the
3 common fields (`datetime`, `level`, `text`), other named capture
groups are added to the metadata map.

Includes lots of additional plumbing to make config available to
parsers.