### PR TITLE
Remove dtparse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,17 +389,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "dtparse"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust_decimal 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,19 +826,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,30 +837,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -915,17 +873,6 @@ dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1358,17 +1305,6 @@ dependencies = [
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1977,7 +1913,6 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossterm 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "dtparse 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonpath 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2077,7 +2012,6 @@ dependencies = [
 "checksum crossterm_winapi 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c061e4a1c47a53952ba0f2396c00a61cd7ab74482eba99b9c9cc77fdca71932"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum dtparse 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8205e3ae069632bf120c90c50db817d9200ba3719eb9384fd1a63a872602a2c5"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
@@ -2128,15 +2062,11 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-"checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-"checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
@@ -2184,7 +2114,6 @@ dependencies = [
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "00eb63f212df0e358b427f0f40aa13aaea010b470be642ad422bcbca2feff2e4"
-"checksum rust_decimal 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a93c95e3d5c1d997e6e4ba9bda898f4e1d73934cd05510c972f10087d0ef00c1"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 serde_yaml = "0.8.8"
 chrono = { version = "0.4.6", features = ["serde"] }
-dtparse = "1.0.3"
 regex = "1.1.2"
 crossterm = "0.8.2"
 lazy_static = "1.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ extern crate atty;
 extern crate chrono;
 #[cfg(not(target_os = "linux"))] extern crate clipboard;
 extern crate crossterm;
-extern crate dtparse;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate maplit;
 extern crate pest;

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -12,7 +12,7 @@ use crate::config::Config;
 use super::types::{
   LogLevel, MappingField, Message, MessageKind, ReaderMetadata
 };
-use super::util::{parse_timestamp, normalize_datetime};
+use super::util::normalize_datetime;
 
 static TIMESTAMP_FIELDS: &[&str] = &["timestamp", "@timestamp", "time", "ts"];
 static LEVEL_FIELDS: &[&str] = &["level"];
@@ -61,7 +61,7 @@ pub fn parse_rfc2822(s: &str) -> Option<DateTime<Utc>> {
 pub fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
   lazy_static! {
     static ref RE: Regex = Regex::new(
-      r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::[\d.]+)?(?:Z|-\d{2}:\d{2})"
+      r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::[\d.]+)?(?:Z|[+-]\d{2}:\d{2})"
     ).unwrap();
   }
 
@@ -72,13 +72,6 @@ pub fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
     }
   } else {
     None
-  }
-}
-
-pub fn parse_freeform(s: &str) -> Option<DateTime<Utc>> {
-  match parse_timestamp(s) {
-    Ok((datetime, offset)) => Some(normalize_datetime(&datetime, offset)),
-    Err(_) => None
   }
 }
 
@@ -94,7 +87,6 @@ pub fn get_timestamp(msg: &Map<String, Value>) -> Option<(&str, DateTime<Utc>)> 
 
     parse_rfc3339(v_str)
       .or_else(|| parse_rfc2822(v_str))
-      .or_else(|| parse_freeform(v_str))
       .and_then(|dt| Some((k, dt)))
   } else {
     None

--- a/src/parser/logrus.rs
+++ b/src/parser/logrus.rs
@@ -176,7 +176,7 @@ mod tests {
   #[test]
   fn test_message() {
     assert_that!(parse_message(
-      r#"time="2019-07-10T14:14:13.950289" level=debug msg="hello world""#
+      r#"time="2019-07-10T14:14:13.950289Z" level=debug msg="hello world""#
     )).is_ok_containing(json!({
       "kind": "logrus",
       "timestamp": "2019-07-10T14:14:13.950289Z",

--- a/src/parser/plain.rs
+++ b/src/parser/plain.rs
@@ -5,12 +5,10 @@ use std::error::Error;
 use std::sync::Arc;
 
 use chrono::prelude::*;
-use dtparse::Parser;
 use regex::RegexSet;
 
 use crate::config::Config;
 use super::types::{LogLevel, Message, MessageKind, ReaderMetadata};
-use super::util::normalize_datetime;
 
 fn get_log_level(line: &str) -> Option<LogLevel> {
   lazy_static! {
@@ -41,47 +39,6 @@ fn get_log_level(line: &str) -> Option<LogLevel> {
   None
 }
 
-/// uses wild guesses to ignore false positive timestamps
-/// dtparse does a pretty good job detecting timestamps when they're actually
-/// present in the string, but almost always returns something when strings
-/// _don't_ actually contain a timestamp
-fn crappy_is_false_positive(line: &str, maybe_tokens: Option<Vec<String>>) -> bool {
-  let tokens = if let Some(tokens) = maybe_tokens {
-    tokens
-  } else {
-    return false;
-  };
-
-  let len_tokens: usize = tokens.iter().map(|t| t.chars().count()).sum();
-  let len_line: i32 = line.chars().count() as i32;
-  let len_consumed_tokens: i32 = len_line - len_tokens as i32;
-
-  // dtparse detects "" as a timestamp :(
-  if len_line == 0 {
-    return true;
-  }
-
-  // probably can't generate a timestamp in fewer characters than a timestamp
-  // (assuming an unhypenated iso8601 w/ missing timezone specifier)
-  if len_consumed_tokens < 15 {
-    return true;
-  }
-
-  // arbitrary, but throw away anything extremely long
-  if len_consumed_tokens > 60 {
-    return true;
-  }
-
-  // in theory a timestamp should make up a small portion of each log line
-  // so, throw away timestamps if they account for more than 75% of the line
-  let timestampiness = len_consumed_tokens as f32 / len_line as f32;
-  if timestampiness > 0.75 {
-    return true;
-  }
-
-  false
-}
-
 fn get_meta_timestamp(meta: &Option<ReaderMetadata>) -> Option<DateTime<Utc>> {
   if let Some(meta) = meta {
     if let Some(timestamp) = meta.timestamp {
@@ -95,39 +52,9 @@ fn get_meta_timestamp(meta: &Option<ReaderMetadata>) -> Option<DateTime<Utc>> {
 pub fn parse_plain(
   _config: Arc<Config>, line: &str, meta: Option<ReaderMetadata>
 ) -> Result<Option<Message>, Box<Error>> {
-  let timestamp = if let Some(timestamp) = get_meta_timestamp(&meta) {
-    Some(timestamp)
-  } else {
-    // TODO: try to remove timestamp from text?
-    // TODO: tzinfos would be nice to detect named timezones...
-    let parser = Parser::default();
-
-    let parse_result = parser.parse(
-      line,
-      None, // dayfirst
-      None, // yearfirst
-      true, // fuzzy
-      true, // fuzzy_with_tokens
-      None, // default
-      false, // ignoretz
-      &HashMap::new() // tzinfos
-    );
-
-    match parse_result {
-      Ok((datetime, offset, tokens)) => {
-        if crappy_is_false_positive(line, tokens) {
-          None
-        } else {
-          Some(normalize_datetime(&datetime, offset))
-        }
-      },
-      Err(_) => None
-    }
-  };
-
   Ok(Some(Message {
     kind: MessageKind::Plain,
-    timestamp,
+    timestamp: get_meta_timestamp(&meta),
     level: get_log_level(line),
     text: Some(String::from(line)),
     metadata: HashMap::new(),

--- a/src/parser/util.rs
+++ b/src/parser/util.rs
@@ -1,9 +1,6 @@
 // (C) Copyright 2019 Hewlett Packard Enterprise Development LP
 
-use std::collections::HashMap;
-
 use chrono::prelude::*;
-use dtparse::{Parser, ParseError};
 
 /// Convert a datetime to UTC if an offset is available
 pub fn normalize_datetime(
@@ -18,24 +15,3 @@ pub fn normalize_datetime(
   // if we can't convert, just assume utc
   Utc.from_utc_datetime(datetime)
 }
-
-/// Leniently parses a timestamp using dtparse
-pub fn parse_timestamp(timestamp: &str) -> Result<(NaiveDateTime, Option<FixedOffset>), ParseError> {
-  let parser = Parser::default();
-
-  // adapted from https://github.com/bspeice/dtparse/blob/master/src/lib.rs#L1285
-  let res = parser.parse(
-    timestamp,
-    None, // dayfirst
-    None, // yearfirst
-    true, // fuzzy
-    false, // fuzzy_with_tokens
-    None, // default
-    false, // ignoretz
-    &HashMap::new() // tzinfos
-  )?;
-
-  Ok((res.0, res.1))
-}
-
-


### PR DESCRIPTION
This removes dtparse, due to a few observed shortcomings:

 - occasional panics on bad unwraps
 - undesirable eprintlns with named timezones
 - poor performance

woodchipper has already implemented some workarounds with fewer
drawbacks, mainly:
 - the new regex parser has configurable timestamp parse strings
 - reader metadata can provide timestamps in kubernetes