### PR TITLE
Add raw output mode

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,7 @@ use crate::renderer;
 pub enum RendererType {
   Auto,
   Plain,
+  Raw,
   Json,
   Styled,
   Interactive
@@ -49,6 +50,7 @@ impl RendererType {
     match *self {
       RendererType::Auto => get_auto_renderer(config),
       RendererType::Plain => renderer::plain_renderer,
+      RendererType::Raw => renderer::raw_renderer,
       RendererType::Json => renderer::json_renderer,
       RendererType::Styled => renderer::styled_renderer,
       RendererType::Interactive => renderer::interactive_renderer,
@@ -63,6 +65,7 @@ impl FromStr for RendererType {
     match s {
       "auto" => Ok(RendererType::Auto),
       "plain" => Ok(RendererType::Plain),
+      "raw" => Ok(RendererType::Raw),
       "json" => Ok(RendererType::Json),
       "styled" => Ok(RendererType::Styled),
       "interactive" => Ok(RendererType::Interactive),

--- a/src/parser/json.rs
+++ b/src/parser/json.rs
@@ -94,6 +94,7 @@ pub fn get_timestamp(msg: &Map<String, Value>) -> Option<(&str, DateTime<Utc>)> 
 }
 
 pub fn parse_document(
+  line: &str,
   kind: MessageKind,
   doc: Map<String, Value>,
   meta: Option<ReaderMetadata>
@@ -143,6 +144,7 @@ pub fn parse_document(
 
   let message = Message {
     kind,
+    raw: line.to_string(),
     reader_metadata: meta,
     timestamp, level, text, metadata, mapped_fields
   };
@@ -159,7 +161,7 @@ pub fn parse_json(
   }
 
   match serde_json::from_str(line) {
-    Ok(message) => parse_document(MessageKind::Json, message, meta),
+    Ok(message) => parse_document(line, MessageKind::Json, message, meta),
     Err(_) => Ok(None)
   }
 }

--- a/src/parser/klog.rs
+++ b/src/parser/klog.rs
@@ -82,6 +82,7 @@ pub fn parse_klog(
     return Ok(Some(Message {
       kind: MessageKind::Klog,
       reader_metadata: meta,
+      raw: line.to_string(),
       text: Some(text.to_string()),
 
       timestamp, level, metadata,

--- a/src/parser/logrus.rs
+++ b/src/parser/logrus.rs
@@ -179,6 +179,7 @@ mod tests {
       r#"time="2019-07-10T14:14:13.950289Z" level=debug msg="hello world""#
     )).is_ok_containing(json!({
       "kind": "logrus",
+      "raw": "time=\"2019-07-10T14:14:13.950289Z\" level=debug msg=\"hello world\"",
       "timestamp": "2019-07-10T14:14:13.950289Z",
       "level": "debug",
       "text": "hello world",
@@ -195,6 +196,7 @@ mod tests {
       r#"animal=walrus number=8"#
     ))).is_ok_containing(json!({
       "kind": "logrus",
+      "raw": "time=\"2015-03-26T01:27:38-04:00\" level=debug msg=\"Started observing beach\" animal=walrus number=8",
       "timestamp": "2015-03-26T05:27:38Z",
       "level": "debug",
       "text": "Started observing beach",
@@ -214,6 +216,7 @@ mod tests {
       r#"number=100 omg=true"#
     ))).is_ok_containing(json!({
       "kind": "logrus",
+      "raw": "time=\"2015-03-26T01:27:38-04:00\" level=fatal msg=\"The ice breaks!\" err=&{0x2082280c0 map[animal:orca size:9009] 2015-03-26 01:27:38.441574009 -0400 EDT panic It\'s over 9000!} number=100 omg=true",
       "timestamp": "2015-03-26T05:27:38Z",
       "level": "fatal",
       "text": "The ice breaks!",

--- a/src/parser/logrus.rs
+++ b/src/parser/logrus.rs
@@ -73,7 +73,7 @@ pub fn parse_logrus(
       if doc.is_empty() {
         Ok(None)
       } else {
-        parse_document(MessageKind::Logrus, doc, meta)
+        parse_document(line, MessageKind::Logrus, doc, meta)
       }
     },
     Err(_) => Ok(None)

--- a/src/parser/plain.rs
+++ b/src/parser/plain.rs
@@ -56,6 +56,7 @@ pub fn parse_plain(
     kind: MessageKind::Plain,
     timestamp: get_meta_timestamp(&meta),
     level: get_log_level(line),
+    raw: line.to_string(),
     text: Some(String::from(line)),
     metadata: HashMap::new(),
     reader_metadata: meta,

--- a/src/parser/regex.rs
+++ b/src/parser/regex.rs
@@ -111,6 +111,7 @@ fn parse_mapping(
   let message = Message {
     kind: MessageKind::Regex,
     reader_metadata: meta.clone(),
+    raw: line.to_string(),
     timestamp, level, text, metadata,
     mapped_fields: HashMap::new()
   };

--- a/src/parser/regex.rs
+++ b/src/parser/regex.rs
@@ -172,7 +172,8 @@ mod tests {
     );
 
     assert_that!(value).is_ok_containing(json!({
-      "kind": "regex"
+      "kind": "regex",
+      "raw": ""
     }));
   }
 
@@ -186,6 +187,7 @@ mod tests {
 
     assert_that!(value).is_ok_containing(json!({
       "kind": "regex",
+      "raw": "2019-10-01T20:40:49Z",
       "timestamp": "2019-10-01T20:40:49Z"
     }));
   }
@@ -201,6 +203,7 @@ mod tests {
     // input dates are normalized to rfc3339 and utc
     assert_that!(value).is_ok_containing(json!({
       "kind": "regex",
+      "raw": "Tue, 1 Jul 2003 10:52:37 +0200",
       "timestamp": "2003-07-01T08:52:37Z"
     }));
   }
@@ -215,6 +218,7 @@ mod tests {
 
     assert_that!(value).is_ok_containing(json!({
       "kind": "regex",
+      "raw": "foo bar",
       "metadata": {
         "a": "foo",
         "b": "bar"
@@ -232,7 +236,8 @@ mod tests {
 
     // invalid date should be null -> not included in json doc
     assert_that!(value).is_ok_containing(json!({
-      "kind": "regex"
+      "kind": "regex",
+      "raw": "2019-10-01T20:40:49Z"
     }));
   }
 
@@ -259,6 +264,7 @@ mod tests {
 
     assert_that!(value).is_ok_containing(json!({
       "kind": "regex",
+      "raw": "I0703 17:19:11.688460       1 controller.go:293] hello world",
       "level": "info",
       "text": "hello world",
       "timestamp": "2019-07-03T17:19:11.688460Z",
@@ -309,6 +315,7 @@ mod tests {
 
     assert_that!(value).is_ok_containing(json!({
       "kind": "regex",
+      "raw": "2019-07-03 12:02:13,977 - DEBUG    - test.py:9 - this is a debug message",
       "level": "debug",
       "text": "this is a debug message",
       "timestamp": "2019-07-03T12:02:13Z",

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -107,6 +107,9 @@ pub struct Message {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub level: Option<LogLevel>,
 
+  // The raw message content
+  pub raw: String,
+
   /// The message text
   #[serde(skip_serializing_if = "Option::is_none")]
   pub text: Option<String>,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -5,6 +5,7 @@ mod common;
 mod json;
 mod plain;
 mod styled;
+mod raw;
 pub mod interactive;
 
 pub use types::*;
@@ -12,3 +13,4 @@ pub use styled::styled_renderer;
 pub use interactive::interactive_renderer;
 pub use plain::plain_renderer;
 pub use json::json_renderer;
+pub use raw::raw_renderer;

--- a/src/renderer/raw.rs
+++ b/src/renderer/raw.rs
@@ -1,0 +1,22 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP
+
+use std::sync::Arc;
+use std::sync::mpsc::Receiver;
+use std::thread::{self, JoinHandle};
+
+use crate::config::Config;
+use crate::renderer::types::*;
+
+pub fn raw_renderer(_: Arc<Config>, rx: Receiver<LogEntry>) -> JoinHandle<()> {
+  thread::Builder::new().name("raw_renderer".to_string()).spawn(move || {
+    for entry in rx {
+      if entry.eof.is_some() {
+        break;
+      }
+
+      if let Some(message) = entry.message {
+        println!("{}", message.message.raw);
+      }
+    }
+  }).unwrap()
+}

--- a/src/renderer/types.rs
+++ b/src/renderer/types.rs
@@ -26,6 +26,7 @@ impl MessageEntry {
       kind: MessageKind::Internal,
       timestamp: Some(Utc::now()),
       level: Some(LogLevel::Int),
+      raw: message.to_string(),
       text: Some(message.to_string()),
       metadata: HashMap::new(),
       reader_metadata: None,


### PR DESCRIPTION
Users may want to use the Kubernetes reader to pull pod logs and
process the raw content elsewhere. This adds a new raw renderer
that outputs the original input.

Note that storing the original message content will increase memory
usage somewhat, though presumably not massively (expect less than 50
MiB per 100k messages).

See also, #42