### PR TITLE
Add configurable refresh rate limit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -278,6 +278,18 @@ pub struct Config {
   )]
   pub fallback_width: usize,
 
+  /// Maximum refresh rate in frames per second (Hz) for the interactive viewer
+  ///
+  /// Lower values may prevent flickering on slow terminals (though really, stop
+  /// using xterm). May also feel slightly smoother at higher values, though
+  /// most terminals won't render this quickly.
+  #[structopt(
+    long,
+    default_value = "40",
+    env = "WD_REFRESH_HZ"
+  )]
+  pub refresh_hz: f32,
+
   /// Styled output configuration
   ///
   /// Must contain one of the following: `default`, `base16:<path to .yaml>`
@@ -286,6 +298,9 @@ pub struct Config {
 
   /// A path to a regexes config file, which may contain custom parsing regexes
   /// for application-specific log formats.
+  ///
+  /// For more info, see: 
+  /// https://github.com/HewlettPackard/woodchipper/blob/master/doc/customization.md#log-formats
   #[structopt(long, env = "WD_REGEXES")]
   pub regexes: Option<RegexConfig>,
 

--- a/src/renderer/interactive/mod.rs
+++ b/src/renderer/interactive/mod.rs
@@ -41,7 +41,7 @@ pub enum InputAction {
 
 pub fn interactive_renderer(config: Arc<Config>, rx: Receiver<LogEntry>) -> JoinHandle<()> {
   thread::Builder::new().name("interactive".to_string()).spawn(move || {
-    let mut rs = Rc::new(RenderState::new(config));
+    let mut rs = Rc::new(RenderState::new(Arc::clone(&config)));
 
     let screen = Screen::default();
     let alt = match screen.enable_alternate_modes(true) {
@@ -51,6 +51,8 @@ pub fn interactive_renderer(config: Arc<Config>, rx: Receiver<LogEntry>) -> Join
         return;
       }
     };
+
+    let sleep_duration_seconds = 1.0f32 / &config.refresh_hz;
 
     let crossterm = Crossterm::from_screen(&alt.screen);
     let cursor = crossterm.cursor();
@@ -124,7 +126,7 @@ pub fn interactive_renderer(config: Arc<Config>, rx: Receiver<LogEntry>) -> Join
         last_render = Some(Instant::now());
       }
 
-      thread::sleep(Duration::from_millis(25));
+      thread::sleep(Duration::from_secs_f32(sleep_duration_seconds));
     }
 
     // attempt to un-hide the cursor on the way out


### PR DESCRIPTION
This adds a new option for users to override the default refresh rate
cap (previously 40hz).

Users of slower terminals may see excessive flickering at this
refresh rate, so now it can be capped lower as needed to reduce
flicker, at least pending a complete overhaul of the renderer.

Alternatively, [alacritty](https://github.com/jwilm/alacritty) is
similarly minimalistic, wildly faster, and doesn't flicker. Maybe
consider upgrading :)